### PR TITLE
added tf and keras versions

### DIFF
--- a/group_norm_experiments.ipynb
+++ b/group_norm_experiments.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/shaoanlu/GroupNormalization-keras/blob/master/group_norm_experiments.ipynb)"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -211,6 +218,33 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%tensorflow_version 1.x # if you are using colab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"tensorflow<2\" # if you are running local"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"keras<2.2\""
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 10,
    "metadata": {
     "colab": {
@@ -258,6 +292,7 @@
     "from keras.layers import Dense, Dropout, Flatten\n",
     "from keras.layers import Conv2D, MaxPooling2D\n",
     "from keras import backend as K\n",
+    "from keras import regularizers\n",
     "\n",
     "import tensorflow  as tf\n",
     "from keras.layers import *"
@@ -924,7 +959,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!wget https://github.com/shaoanlu/faceswap-GAN/raw/master/instance_normalization.py"
+    "!wget https://raw.githubusercontent.com/shaoanlu/faceswap-GAN/master/networks/instance_normalization.py"
    ]
   },
   {
@@ -2283,7 +2318,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.8.3-final"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi.
- added installation tf version below 2.0 and keras under 2.2;
- added `from keras import regularizers`, which is used later;
- corrected link for `instance_normalization.py` downloading;
- added colab badge on top.